### PR TITLE
add new Parse signature of ValueNodeParser delegate to XmlConfigurationParser

### DIFF
--- a/Vostok.Configuration.Sources.Xml.Tests/XmlConfigurationParser_Tests.cs
+++ b/Vostok.Configuration.Sources.Xml.Tests/XmlConfigurationParser_Tests.cs
@@ -36,7 +36,7 @@ namespace Vostok.Configuration.Sources.Xml.Tests
     <Key1>value1</Key1>
     <Key2>value2</Key2>
 </Dictionary>";
-            
+
             var settings = XmlConfigurationParser.Parse(value);
 
             settings.Name.Should().Be("Dictionary");
@@ -52,7 +52,7 @@ namespace Vostok.Configuration.Sources.Xml.Tests
     <Array>value1</Array>
     <Array>value2</Array>
 </ArrayParent>";
-            
+
             var settings = XmlConfigurationParser.Parse(value);
 
             settings.Name.Should().Be("ArrayParent");
@@ -79,7 +79,7 @@ namespace Vostok.Configuration.Sources.Xml.Tests
             settings["item"].Children.First()["subitem1"].Value.Should().Be("value1");
             settings["item"].Children.Last()["subitem2"].Value.Should().Be("value2");
         }
-        
+
         [Test]
         public void Should_parse_ArrayOfArrays_value()
         {
@@ -115,7 +115,7 @@ namespace Vostok.Configuration.Sources.Xml.Tests
     <ArrayItem>ArrayValue1</ArrayItem>
     <ArrayItem>ArrayValue2</ArrayItem>
 </Mixed>";
-            
+
             var settings = XmlConfigurationParser.Parse(value);
 
             settings.Name.Should().Be("Mixed");
@@ -123,7 +123,7 @@ namespace Vostok.Configuration.Sources.Xml.Tests
             settings["DictItem"]["DictKey"].Value.Should().Be("DictValue");
             settings["ArrayItem"].Children.Select(child => child.Value).Should().Equal("ArrayValue1", "ArrayValue2");
         }
-        
+
         [Test]
         public void Should_parse_Object_from_attributes()
         {
@@ -149,7 +149,7 @@ namespace Vostok.Configuration.Sources.Xml.Tests
             settings["item"].Children.Select(child => child.Value).Should().Equal("value1", "value2");
             settings["attr"].Value.Should().Be("test");
         }
-        
+
         [Test]
         public void Should_ignore_key_case()
         {
@@ -163,6 +163,16 @@ namespace Vostok.Configuration.Sources.Xml.Tests
          {
              const string value = "wrong file format";
              new Action(() => { XmlConfigurationParser.Parse(value); }).Should().Throw<XmlException>();
+         }
+
+         [Test]
+         public void Should_parse_XmlDocument_with_overriden_root_name()
+         {
+             var settings = XmlConfigurationParser.Parse("<object key1='val1' key2='val2' />", "overriden");
+
+             settings.Name.Should().Be("overriden");
+             settings["key1"].Value.Should().Be("val1");
+             settings["key2"].Value.Should().Be("val2");
          }
     }
 }

--- a/Vostok.Configuration.Sources.Xml/XmlConfigurationParser.cs
+++ b/Vostok.Configuration.Sources.Xml/XmlConfigurationParser.cs
@@ -10,19 +10,24 @@ namespace Vostok.Configuration.Sources.Xml
     public static class XmlConfigurationParser
     {
         public static ISettingsNode Parse(string content)
+            => ParseXml(content, null);
+
+        public static ISettingsNode Parse(string content, string rootName)
+            => ParseXml(content, rootName);
+
+        private static ISettingsNode ParseXml(string content, string rootName)
         {
             if (string.IsNullOrWhiteSpace(content))
                 return null;
 
             var doc = new XmlDocument();
-
             doc.LoadXml(content);
 
-            var root = doc.DocumentElement;
+            var root = doc?.DocumentElement;
             if (root == null)
                 return null;
 
-            return ParseElement(doc, root.Name, root);
+            return ParseElement(doc, rootName ?? root.Name, root);
         }
 
         private static ISettingsNode ParseElement(XmlDocument doc, string name, XmlElement element)
@@ -46,7 +51,6 @@ namespace Vostok.Configuration.Sources.Xml
             if (!childNodes.OfType<XmlElement>().Any())
                 return new ValueNode(name, element.InnerText);
 
-
             var children =
                 childNodes
                     .Cast<XmlElement>()
@@ -56,9 +60,9 @@ namespace Vostok.Configuration.Sources.Xml
                             elements.Count() == 1
                                 ? ParseElement(doc, elements.Key, elements.First())
                                 : new ArrayNode(elements.Key, elements.Select((node, index) => ParseElement(doc, index.ToString(), node)).ToList())
-                )
-                .ToList();
-            
+                    )
+                    .ToList();
+
             return new ObjectNode(name, children);
         }
     }


### PR DESCRIPTION
this makes it possible to pass `XmlConfigurationParser.Parse` method to `ClusterConfigSourceSettings.ConditionalValuesParsers`